### PR TITLE
Renamed env-Value MQTT_BROKER

### DIFF
--- a/encodapy/config/default_values.py
+++ b/encodapy/config/default_values.py
@@ -28,7 +28,7 @@ class DefaultEnvVariables(Enum):
     TIME_FORMAT_FILE = "%d.%m.%Y %H:%M"
     RELOAD_STATICDATA = False
 
-    MQTT_BROKER = "localhost"
+    MQTT_HOST = "localhost"
     MQTT_PORT = 1883
     MQTT_USERNAME = ""
     MQTT_PASSWORD = ""

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -75,8 +75,8 @@ class MqttConnection:
             "MQTT_TOPIC_PREFIX", DefaultEnvVariables.MQTT_TOPIC_PREFIX.value
         )
 
-        if not self.mqtt_params["broker"] or not self.mqtt_params["port"]:
-            raise ConfigError("MQTT broker and port must be set")
+        if not self.mqtt_params["host"] or not self.mqtt_params["port"]:
+            raise ConfigError("MQTT host and port must be set")
 
     def prepare_mqtt_connection(self) -> None:
         """

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -55,8 +55,8 @@ class MqttConnection:
         or use the default values from the DefaultEnvVariables class.
         """
         # the IP of the broker
-        self.mqtt_params["broker"] = os.environ.get(
-            "MQTT_BROKER", DefaultEnvVariables.MQTT_BROKER.value
+        self.mqtt_params["host"] = os.environ.get(
+            "MQTT_HOST", DefaultEnvVariables.MQTT_HOST.value
         )
         # the port of the broker
         self.mqtt_params["port"] = int(
@@ -90,17 +90,17 @@ class MqttConnection:
 
         # set username and password for the MQTT client
         self.mqtt_client.username_pw_set(
-            self.mqtt_params["username"], self.mqtt_params["password"]
+            username=self.mqtt_params["username"], password=self.mqtt_params["password"]
         )
 
         # try to connect to the MQTT broker
         try:
             self.mqtt_client.connect(
-                self.mqtt_params["broker"], self.mqtt_params["port"]
+                host=self.mqtt_params["host"], port=self.mqtt_params["port"]
             )
         except Exception as e:
             raise ConfigError(
-                f"Could not connect to MQTT broker {self.mqtt_params['broker']}:"
+                f"Could not connect to MQTT broker {self.mqtt_params['host']}:"
                 f"{self.mqtt_params['port']} with given login information - {e}"
             ) from e
 

--- a/examples/05_simple_service_mqtt/readme.md
+++ b/examples/05_simple_service_mqtt/readme.md
@@ -12,7 +12,7 @@ As an example of a simple service using Encodapy with a MQTT interface, a heatin
 To run the example, you could optionally add a `.env` file with the following content (if you do not add your own, the here written standard values will be used):
 
 ```env
-MQTT_BROKER="localhost"  # URL of the MQTT Broker
+MQTT_HOST="localhost"    # URL of the MQTT Broker
 MQTT_PORT=1883           # Port of the MQTT Broker
 MQTT_USERNAME=""         # if required
 MQTT_PASSWORD=""         # if required
@@ -35,6 +35,7 @@ For the models of the inputs and outputs, see [02_datatransfer](./../02_datatran
 For the possible payloads, see [03_interfaces](./../03_interfaces/).
 
 ## Usage
+
 - To use it, the `.env` file must be created and an MQTT broker with the data in the `.env` file must be available so that a connection can be established.
 - The service is started by executing [`main.py`](./main.py) from the current path.
 - New data can be sent by running the script [`storage_dummy.py`](./storage_dummy.py).

--- a/examples/05_simple_service_mqtt/storage_dummy.py
+++ b/examples/05_simple_service_mqtt/storage_dummy.py
@@ -9,14 +9,14 @@ import time
 import paho.mqtt.client as mqtt
 from paho.mqtt.enums import CallbackAPIVersion
 
-MQTT_BROKER = os.environ.get("MQTT_BROKER", "localhost")
+MQTT_HOST = os.environ.get("MQTT_HOST", "localhost")
 MQTT_PORT = int(os.environ.get("MQTT_PORT", 1883))
 MQTT_TOPIC_PREFIX = os.environ.get("MQTT_TOPIC_PREFIX", "")
 
 if __name__ == "__main__":
     client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2)
 
-    client.connect(MQTT_BROKER, MQTT_PORT, 60)
+    client.connect(MQTT_HOST, MQTT_PORT, 60)
 
     # 1. Send "22.5 °C" as plain string to thermal_storage/t_sen_bot
     topic1 = f"{MQTT_TOPIC_PREFIX}thermal_storage/t_sen_bot"

--- a/examples/05_simple_service_mqtt/storage_dummy.py
+++ b/examples/05_simple_service_mqtt/storage_dummy.py
@@ -34,9 +34,10 @@ if __name__ == "__main__":
 
     time.sleep(10)
 
-    # 3. Send {"t_sen_bot": 22.5, "t_sen_set": 45} as JSON to thermal_storage
+    # 3. Send {"t_sen_bot": 22.5, "t_sen_set": "45"} as JSON to thermal_storage,
+    # even different value types are possible (Number as string will be converted automatically)
     topic3 = f"{MQTT_TOPIC_PREFIX}thermal_storage"
-    payload3 = json.dumps({"t_sen_bot": 22.5, "t_sen_set": 45})
+    payload3 = json.dumps({"t_sen_bot": 22.5, "t_sen_set": "45"})
     client.publish(topic3, payload3)
     print(f"Published to {topic3}: {payload3}")
 


### PR DESCRIPTION
Due to the similarity in names in the filip package, but different usage, the global variable MQTT_BROKER is renamed to MQTT_HOST.