### PR TITLE
78 optional time delay after publishing a mqtt message

### DIFF
--- a/encodapy/config/env_values.py
+++ b/encodapy/config/env_values.py
@@ -140,9 +140,12 @@ class MQTTEnvVariables(BaseSettings):
     )
     publish_delay: float = Field(
         default=0.0,
-        description=("Delay in seconds before publishing MQTT messages. "
-                     "Can be used to ensure correct ordering of messages or "
-                     "to give slow clients sufficient time to receive them."),
+        description=(
+            "Delay in seconds before publishing MQTT messages. "
+            "Can be used to give slow clients sufficient time to receive everything. "
+            "Be careful when using this option, as unexpected behaviour may occur if the "
+            "delay of all messages is longer than the sampling time."
+        ),
     )
 
 

--- a/encodapy/config/env_values.py
+++ b/encodapy/config/env_values.py
@@ -138,6 +138,12 @@ class MQTTEnvVariables(BaseSettings):
             "Only use for testing purposes."
         ),
     )
+    publish_delay: float = Field(
+        default=0.0,
+        description=("Delay in seconds before publishing MQTT messages. "
+                     "Can be used to ensure correct ordering of messages or "
+                     "to give slow clients sufficient time to receive them."),
+    )
 
 
 class FileEnvVariables(BaseSettings):
@@ -162,4 +168,3 @@ class FileEnvVariables(BaseSettings):
     path_of_results: str = Field(
         default="./results", description="Directory path to store the results"
     )
-

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -257,18 +257,9 @@ class MQTTTemplateConfig(BaseModel):
             in_topic = param in topic_template
             in_payload = param in payload_template
 
-            if in_topic and in_payload:
-                continue
-
             if not in_topic and not in_payload:
                 logger.debug(
                     f"Parameter {param} not found in MQTT template for topic and payload."
-                )
-            elif not in_topic:
-                logger.debug(f"Parameter {param} not found in MQTT template for topic.")
-            else:
-                logger.debug(
-                    f"Parameter {param} not found in MQTT template for payload."
                 )
 
     @classmethod

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -146,7 +146,9 @@ class MQTTTemplateConfig(BaseModel):
                 f"got {type(mqtt_format_template).__name__} ({mqtt_format_template})."
             )
 
-        cls._log_missing_params(mqtt_format_template)
+        cls._log_missing_params(
+            mqtt_format_data=mqtt_format_template,
+            name=mqtt_format_template_env)
 
         return {
             "topic": cls.load_mqtt_template(
@@ -207,7 +209,9 @@ class MQTTTemplateConfig(BaseModel):
         if "payload" not in mqtt_format_data:
             raise ValueError("MQTT template dict must contain 'payload' key.")
 
-        cls._log_missing_params(mqtt_format_data)
+        cls._log_missing_params(
+            mqtt_format_data=mqtt_format_data,
+            name="dict_input") # there is no name
 
         return {
             "topic": cls.load_mqtt_template(
@@ -220,12 +224,16 @@ class MQTTTemplateConfig(BaseModel):
         }
 
     @classmethod
-    def _log_missing_params(cls, mqtt_format_data: dict) -> None:
+    def _log_missing_params(cls,
+                            mqtt_format_data: dict,
+                            name: Optional[str] = None
+                            ) -> None:
         """
         Log missing parameters per template part once.
 
         Args:
             mqtt_format_data: Dictionary containing `topic` and `payload` templates.
+            name: Optional name of the template for logging context.
         """
         topic_raw = mqtt_format_data.get("topic", {})
         payload_raw = mqtt_format_data.get("payload", {})
@@ -259,7 +267,7 @@ class MQTTTemplateConfig(BaseModel):
 
             if not in_topic and not in_payload:
                 logger.debug(
-                    f"Parameter {param} not found in MQTT template for topic and payload."
+                    f"Parameter {param} not found in MQTT template '{name}' for topic and payload."
                 )
 
     @classmethod

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -146,6 +146,8 @@ class MQTTTemplateConfig(BaseModel):
                 f"got {type(mqtt_format_template).__name__} ({mqtt_format_template})."
             )
 
+        cls._log_missing_params(mqtt_format_template)
+
         return {
             "topic": cls.load_mqtt_template(
                 template_raw=mqtt_format_template, part="topic"
@@ -205,6 +207,8 @@ class MQTTTemplateConfig(BaseModel):
         if "payload" not in mqtt_format_data:
             raise ValueError("MQTT template dict must contain 'payload' key.")
 
+        cls._log_missing_params(mqtt_format_data)
+
         return {
             "topic": cls.load_mqtt_template(
                 template_raw=mqtt_format_data, part="topic"
@@ -214,6 +218,58 @@ class MQTTTemplateConfig(BaseModel):
             ),
             "time_format": cls._handle_time_format(mqtt_format_data),
         }
+
+    @classmethod
+    def _log_missing_params(cls, mqtt_format_data: dict) -> None:
+        """
+        Log missing parameters per template part once.
+
+        Args:
+            mqtt_format_data: Dictionary containing `topic` and `payload` templates.
+        """
+        topic_raw = mqtt_format_data.get("topic", {})
+        payload_raw = mqtt_format_data.get("payload", {})
+
+        if isinstance(topic_raw, dict):
+            topic_template = json.dumps(topic_raw)
+        elif isinstance(topic_raw, str):
+            topic_template = topic_raw
+        else:
+            topic_template = ""
+
+        if isinstance(payload_raw, dict):
+            payload_template = json.dumps(payload_raw)
+        elif isinstance(payload_raw, str):
+            payload_template = payload_raw
+        else:
+            payload_template = ""
+
+        parameters = [
+            "__OUTPUT_ENTITY__",
+            "__OUTPUT_ATTRIBUTE__",
+            "__OUTPUT_VALUE__",
+            "__OUTPUT_UNIT__",
+            "__OUTPUT_TIME__",
+            "__MQTT_TOPIC_PREFIX__",
+        ]
+
+        for param in parameters:
+            in_topic = param in topic_template
+            in_payload = param in payload_template
+
+            if in_topic and in_payload:
+                continue
+
+            if not in_topic and not in_payload:
+                logger.debug(
+                    f"Parameter {param} not found in MQTT template for topic and payload."
+                )
+            elif not in_topic:
+                logger.debug(f"Parameter {param} not found in MQTT template for topic.")
+            else:
+                logger.debug(
+                    f"Parameter {param} not found in MQTT template for payload."
+                )
 
     @classmethod
     def load_mqtt_template(cls, template_raw: dict, part: str) -> Template:
@@ -261,11 +317,6 @@ class MQTTTemplateConfig(BaseModel):
                 else:
                     clean_name = param.strip("_").lower()
                     template = template.replace(param, f"{{{{{clean_name}}}}}")
-
-            else:
-                logger.debug(
-                    f"Parameter {param} not found in payload template for {part}."
-                )
 
         return Template(template)
 

--- a/encodapy/service/basic_service.py
+++ b/encodapy/service/basic_service.py
@@ -2,21 +2,23 @@
 Module for the basic service class for the data processing and transfer via different interfaces.
 Author: Martin Altenburger
 """
+
+import asyncio
 import sys
 from datetime import datetime
 from typing import Optional, Union
-import asyncio
+
 from loguru import logger
 from pydantic import ValidationError
 
 from encodapy.config import (
     AttributeModel,
+    BasicEnvVariables,
     CommandModel,
     ConfigModel,
     DataQueryTypes,
     Interfaces,
     OutputModel,
-    BasicEnvVariables
 )
 from encodapy.service.communication import (
     FileConnection,
@@ -86,7 +88,6 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
             self.load_mqtt_params()
 
         logger.debug("Config succesfully loaded.")
-
 
     def prepare_basic_start(self):
         """
@@ -228,7 +229,9 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
                     )
                     output_timestamps.append(entity_timestamps)
                     output_latest_timestamps.append(output_latest_timestamp)
-                    logger.debug("File interface, output_latest_timestamp is not defined.")
+                    logger.debug(
+                        "File interface, output_latest_timestamp is not defined."
+                    )
 
                 case Interfaces.MQTT:
                     entity_timestamps, output_latest_timestamp = (
@@ -259,7 +262,9 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
                         input_data.append(fiware_input)
 
                 case Interfaces.FILE:
-                    file_input = self.get_data_from_file(method=method, entity=input_entity)
+                    file_input = self.get_data_from_file(
+                        method=method, entity=input_entity
+                    )
                     if file_input is not None:
                         input_data.append(file_input)
 
@@ -418,7 +423,8 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
                 )
 
             elif output_entity.interface is Interfaces.MQTT:
-                self.send_data_to_mqtt(
+                await asyncio.to_thread(
+                    self.send_data_to_mqtt,
                     output_entity=output_entity,
                     output_attributes=output_attributes,
                 )

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -7,8 +7,10 @@ Author: Maximilian Beyer, Martin Altenburger
 import json
 import re
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Optional, Union
+
 import paho.mqtt.client as mqtt
 from loguru import logger
 from paho.mqtt.enums import CallbackAPIVersion
@@ -90,7 +92,7 @@ class MqttConnection:
                 if self.mqtt_params.tls_ca_cert:
                     logger.debug(
                         f"TLS/SSL configured with CA certificate: {self.mqtt_params.tls_ca_cert}"
-                        )
+                    )
                 else:
                     logger.debug("TLS/SSL configured using system default certificates")
             except (ValueError, OSError) as e:
@@ -99,9 +101,7 @@ class MqttConnection:
                 ) from e
 
         # try to connect to the MQTT broker
-        self.mqtt_client.connect(
-            host=self.mqtt_params.host, port=self.mqtt_params.port
-        )
+        self.mqtt_client.connect(host=self.mqtt_params.host, port=self.mqtt_params.port)
         # start the MQTT client loop
         self.start_mqtt_client()
 
@@ -114,7 +114,6 @@ class MqttConnection:
 
         # prepare the message store
         self.prepare_mqtt_message_store()
-
 
     def prepare_mqtt_message_store(self) -> None:
         """
@@ -265,6 +264,8 @@ class MqttConnection:
             )
 
         payload = self.prepare_payload_for_publish(payload)
+        if self.mqtt_params.publish_delay > 0.0:
+            time.sleep(self.mqtt_params.publish_delay)
         self.mqtt_client.publish(topic, payload)
         logger.debug(f"Published to topic {topic}: {payload}")
 
@@ -334,16 +335,16 @@ class MqttConnection:
         if rc == 0:
             self._mqtt_connected = True
             self._mqtt_connection_event.set()
-            logger.debug("MQTT connection successful to broker "
-                         f"{self.mqtt_params.host}:{self.mqtt_params.port}")
+            logger.debug(
+                "MQTT connection successful to broker "
+                f"{self.mqtt_params.host}:{self.mqtt_params.port}"
+            )
 
             try:
                 self.subscribe_to_message_store_topics()
             except NotSupportedError as e:
                 # Message store may be uninitialized or empty; log and continue
-                logger.debug(
-                    f"MQTT message store subscriptions not restored: {e}"
-                )
+                logger.debug(f"MQTT message store subscriptions not restored: {e}")
         else:
             self._mqtt_connected = False
             logger.error(f"MQTT connection failed with result code {rc}")
@@ -355,8 +356,10 @@ class MqttConnection:
         self._mqtt_connected = False
         self._mqtt_connection_event.clear()
         if rc != 0:
-            logger.warning(f"MQTT disconnected unexpectedly with result code {rc}. "
-                           "Will attempt automatic reconnection.")
+            logger.warning(
+                f"MQTT disconnected unexpectedly with result code {rc}. "
+                "Will attempt automatic reconnection."
+            )
         else:
             logger.debug("MQTT disconnected")
 

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -10,10 +10,12 @@ import threading
 import time
 from datetime import datetime, timezone
 from typing import Optional, Union
+
 import paho.mqtt.client as mqtt
 from loguru import logger
 from paho.mqtt.enums import CallbackAPIVersion
 from pandas import DataFrame
+
 from encodapy.config import (
     ConfigModel,
     DataQueryTypes,
@@ -98,6 +100,9 @@ class MqttConnection:
                     f"Failed to configure TLS/SSL for MQTT connection: {e}"
                 ) from e
 
+        # prepare the message store
+        self.prepare_mqtt_message_store()
+
         # try to connect to the MQTT broker
         self.mqtt_client.connect(host=self.mqtt_params.host, port=self.mqtt_params.port)
         # start the MQTT client loop
@@ -109,9 +114,6 @@ class MqttConnection:
             raise ConfigError(
                 f"Could not establish initial MQTT connection after {max_wait} seconds."
             )
-
-        # prepare the message store
-        self.prepare_mqtt_message_store()
 
     def prepare_mqtt_message_store(self) -> None:
         """

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -10,12 +10,10 @@ import threading
 import time
 from datetime import datetime, timezone
 from typing import Optional, Union
-
 import paho.mqtt.client as mqtt
 from loguru import logger
 from paho.mqtt.enums import CallbackAPIVersion
 from pandas import DataFrame
-
 from encodapy.config import (
     ConfigModel,
     DataQueryTypes,

--- a/examples/05_simple_service_mqtt/config.json
+++ b/examples/05_simple_service_mqtt/config.json
@@ -49,12 +49,12 @@
                 {
                     "id": "status",
                     "id_interface": "status",
-                    "mqtt_format": "template_example03"
+                    "mqtt_format": "template_example05"
                 },
                 {
                     "id": "status",
                     "id_interface": "status",
-                    "mqtt_format": "template_example03"
+                    "mqtt_format": "template_example05"
                 }
             ],
             "commands": []

--- a/examples/05_simple_service_mqtt/readme.md
+++ b/examples/05_simple_service_mqtt/readme.md
@@ -9,7 +9,7 @@ As an example of a simple service using Encodapy with a MQTT interface, a heatin
 - [main.py](./main.py): Script to start the service
 - [storage_dummy.py](./storage_dummy.py): Script to send different types of mqtt messages from a dummy storage to the service
 
-To run the example, you **need to add** a `.env` file with the content for MQTT_TEMPLATE_EXAMPLE03 (if you do not add the others, the here written standard values will be used):
+To run the example, you **need to add** a `.env` file with the content for MQTT_TEMPLATE_EXAMPLE05 (if you do not add the others, the here written standard values will be used):
 
 ```env
 MQTT_TEMPLATE_EXAMPLE05 = "custom_mqtt_template.json" # the only mandatory information

--- a/examples/05_simple_service_mqtt/readme.md
+++ b/examples/05_simple_service_mqtt/readme.md
@@ -12,7 +12,7 @@ As an example of a simple service using Encodapy with a MQTT interface, a heatin
 To run the example, you **need to add** a `.env` file with the content for MQTT_TEMPLATE_EXAMPLE03 (if you do not add the others, the here written standard values will be used):
 
 ```env
-MQTT_TEMPLATE_EXAMPLE03 = "custom_mqtt_template.json" # the only mandatory information
+MQTT_TEMPLATE_EXAMPLE05 = "custom_mqtt_template.json" # the only mandatory information
 
 MQTT_HOST="localhost"    # URL of the MQTT Broker
 MQTT_PORT=1883           # Port of the MQTT Broker


### PR DESCRIPTION
This pull request introduces improvements to MQTT message handling and configuration, focusing on enhanced debugging for template parameters and more flexible message publishing. The main changes include adding a configurable publish delay for MQTT messages, improved logging for missing template parameters, and updates to example configurations.

**MQTT publishing and configuration enhancements:**

* Added a new `publish_delay` field to `MQTTEnvVariables` in `encodapy/config/env_values.py`, allowing users to specify a delay (in seconds) before publishing MQTT messages, which can help slow clients receive messages reliably. [[1]](diffhunk://#diff-7fe586a4c926fa6e82afaf624d23669bb9e0eeb21478bd78aac437b9d45d93fbR141-R149) [[2]](diffhunk://#diff-2160e99ccdc373464ed9720ec6a3a026b30a814bfbd835d85eee4c19e398ab84R267-R268)
* Updated the `publish` method in `MQTTConnection` to honor the new `publish_delay` parameter by sleeping for the specified duration before sending each message.

**MQTT template debugging improvements:**

* Introduced a `_log_missing_params` method to `MQTTMessageTemplate` in `encodapy/config/mqtt_messages_template.py`, which logs debug messages if expected parameters are missing from the topic or payload templates. This method is now called when loading or handling MQTT message templates, making it easier to spot template issues. [[1]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR149-R150) [[2]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR210-R211) [[3]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR222-R273)
* Removed redundant debug logging from `load_mqtt_template` since missing parameter logging is now centralized.

**Example and documentation updates:**

* Updated the example configuration in `examples/05_simple_service_mqtt/config.json` and `readme.md` to use `template_example05` and the corresponding environment variable, aligning the documentation with the new template naming convention. [[1]](diffhunk://#diff-26a18e9a8634cee9d86f0bb84cae28a2aa71e2764a40acfb43b98f051540848fL52-R57) [[2]](diffhunk://#diff-883676b2d1e1cf3b7633a56cd51cf5543f1a8ff50b6928669d36963051550bd2L15-R15)

**Minor code formatting and logging improvements:**

* Improved formatting and readability of logger statements in `mqtt_connection.py` for connection and disconnection events. [[1]](diffhunk://#diff-2160e99ccdc373464ed9720ec6a3a026b30a814bfbd835d85eee4c19e398ab84L337-R347) [[2]](diffhunk://#diff-2160e99ccdc373464ed9720ec6a3a026b30a814bfbd835d85eee4c19e398ab84L358-R362)
* Minor cleanup in `FileEnvVariables` and import ordering. [[1]](diffhunk://#diff-7fe586a4c926fa6e82afaf624d23669bb9e0eeb21478bd78aac437b9d45d93fbL165) [[2]](diffhunk://#diff-2160e99ccdc373464ed9720ec6a3a026b30a814bfbd835d85eee4c19e398ab84R10-R13)