### PR TITLE
Fix None Values

### DIFF
--- a/encodapy/config/env_values.py
+++ b/encodapy/config/env_values.py
@@ -170,6 +170,14 @@ class MQTTEnvVariables(BaseSettings):
             "delay of all messages is longer than the sampling time."
         ),
     )
+    skip_none_values: bool = Field(
+        default=True,
+        description=(
+            "If True, attributes with None values will not be published to MQTT. "
+            "This can help reduce message size and avoid sending irrelevant data. "
+            "Default is True, meaning None values will not be published."
+        )
+    )
 
 
 class FileEnvVariables(BaseSettings):

--- a/encodapy/service/basic_service.py
+++ b/encodapy/service/basic_service.py
@@ -544,14 +544,10 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
                 if output.id not in output_attrs:
                     output_attrs[output.id] = []
 
-                attribute.value = (
-                    component.value if component.value is not None else attribute.value
-                )
-
                 output_attrs[output.id].append(
                     AttributeModel(
                         id=attribute.id,
-                        value=attribute.value,
+                        value=component.value,
                         unit=component.unit,
                         timestamp=component.timestamp,
                     )
@@ -571,13 +567,8 @@ class ControllerBasicService(FiwareConnection, FileConnection, MqttConnection):
                 if output.id not in output_cmds:
                     output_cmds[output.id] = []
 
-                # TODO: type checking necessary? Dataframes and bools not allowed for commands
-                command.value = (
-                    component.value if component.value is not None else command.value
-                )
-
                 output_cmds[output.id].append(
-                    CommandModel(id=command.id, value=command.value)
+                    CommandModel(id=command.id, value=component.value)
                 )
                 break
         return output_cmds

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -810,6 +810,12 @@ class MqttConnection:
 
         # publish the data to the MQTT broker
         for attribute in output_attributes:
+            if attribute.value is None and self.mqtt_params.skip_none_values:
+                logger.debug(
+                    f"Skip MQTT publish for attribute {attribute.id} of entity {output_entity.id}: "
+                    "value is None."
+                )
+                continue
             try:
                 self.publish(
                     topic=self._prepare_mqtt_topic(


### PR DESCRIPTION
With this branch, `None` values are sent directly to the output.

At the same time, this allows values to be excluded from being sent via MQTT. This is controlled via an environment variable.

The PR will close the issue #93.