### PR TITLE
Fix template errors, implement MQTT template rendering and tests

### DIFF
--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Union
 
 from jinja2 import Template
 from loguru import logger
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.functional_validators import model_validator
 
 from encodapy.config.types import MQTTFormatTypes
@@ -76,6 +76,7 @@ class MQTTTemplateConfig(BaseModel):
     topic: Template
     payload: Template
     time_format: str = "%Y-%m-%dT%H:%M:%S%z"
+    payload_embedded_placeholders: set[str] = Field(default_factory=set)
 
     @model_validator(mode="before")
     @classmethod
@@ -154,6 +155,9 @@ class MQTTTemplateConfig(BaseModel):
                 template_raw=mqtt_format_template, part="payload"
             ),
             "time_format": cls._handle_time_format(mqtt_format_template),
+            "payload_embedded_placeholders": cls._collect_embedded_payload_placeholders(
+                mqtt_format_template.get("payload", {})
+            ),
         }
 
     @classmethod
@@ -213,7 +217,49 @@ class MQTTTemplateConfig(BaseModel):
                 template_raw=mqtt_format_data, part="payload"
             ),
             "time_format": cls._handle_time_format(mqtt_format_data),
+            "payload_embedded_placeholders": cls._collect_embedded_payload_placeholders(
+                mqtt_format_data.get("payload", {})
+            ),
         }
+
+    @classmethod
+    def _collect_embedded_payload_placeholders(cls, value: Any) -> set[str]:
+        """
+        Collect placeholder variable names used inside longer payload strings.
+        """
+        placeholder_map = {
+            "__OUTPUT_ENTITY__": "output_entity",
+            "__OUTPUT_ATTRIBUTE__": "output_attribute",
+            "__OUTPUT_VALUE__": "output_value",
+            "__OUTPUT_UNIT__": "output_unit",
+            "__OUTPUT_TIME__": "output_time",
+            "__MQTT_TOPIC_PREFIX__": "mqtt_topic_prefix",
+        }
+
+        if isinstance(value, dict):
+            embedded_placeholder_names_from_dict: set[str] = set()
+            for item in value.values():
+                embedded_placeholder_names_from_dict.update(
+                    cls._collect_embedded_payload_placeholders(item)
+                )
+            return embedded_placeholder_names_from_dict
+
+        if isinstance(value, list):
+            embedded_placeholder_names_from_list: set[str] = set()
+            for item in value:
+                embedded_placeholder_names_from_list.update(
+                    cls._collect_embedded_payload_placeholders(item)
+                )
+            return embedded_placeholder_names_from_list
+
+        if isinstance(value, str) and value not in placeholder_map:
+            return {
+                clean_name
+                for placeholder, clean_name in placeholder_map.items()
+                if placeholder in value
+            }
+
+        return set()
 
     @classmethod
     def load_mqtt_template(cls, template_raw: dict, part: str) -> Template:

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -269,6 +269,8 @@ class MQTTTemplateConfig(BaseModel):
                 if part == "payload":
                     return f"{{{{{clean_name} | tojson}}}}"
                 return f"{{{{{clean_name}}}}}"
+            for placeholder, clean_name in placeholder_map.items():
+                value = value.replace(placeholder, f"{{{{{clean_name}}}}}")
             if part == "payload":
                 return json.dumps(value)
             return value

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -6,7 +6,7 @@ Author: Martin Altenburger
 import json
 import os
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 
 from jinja2 import Template
 from loguru import logger
@@ -70,6 +70,16 @@ class MQTTTemplateConfig(BaseModel):
     Raises:
         ValueError: If the input is invalid or templates cannot be loaded.
     """
+
+    # Mapping from placeholder token to variable name for MQTT template rendering
+    PLACEHOLDER_TO_VARIABLE: ClassVar[dict[str, str]] = {
+        "__OUTPUT_ENTITY__": "output_entity",
+        "__OUTPUT_ATTRIBUTE__": "output_attribute",
+        "__OUTPUT_VALUE__": "output_value",
+        "__OUTPUT_UNIT__": "output_unit",
+        "__OUTPUT_TIME__": "output_time",
+        "__MQTT_TOPIC_PREFIX__": "mqtt_topic_prefix",
+    }
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -227,15 +237,6 @@ class MQTTTemplateConfig(BaseModel):
         """
         Collect placeholder variable names used inside longer payload strings.
         """
-        placeholder_map = {
-            "__OUTPUT_ENTITY__": "output_entity",
-            "__OUTPUT_ATTRIBUTE__": "output_attribute",
-            "__OUTPUT_VALUE__": "output_value",
-            "__OUTPUT_UNIT__": "output_unit",
-            "__OUTPUT_TIME__": "output_time",
-            "__MQTT_TOPIC_PREFIX__": "mqtt_topic_prefix",
-        }
-
         if isinstance(value, dict):
             embedded_placeholder_names_from_dict: set[str] = set()
             for item in value.values():
@@ -252,10 +253,10 @@ class MQTTTemplateConfig(BaseModel):
                 )
             return embedded_placeholder_names_from_list
 
-        if isinstance(value, str) and value not in placeholder_map:
+        if isinstance(value, str) and value not in cls.PLACEHOLDER_TO_VARIABLE:
             return {
                 clean_name
-                for placeholder, clean_name in placeholder_map.items()
+                for placeholder, clean_name in cls.PLACEHOLDER_TO_VARIABLE.items()
                 if placeholder in value
             }
 
@@ -310,12 +311,12 @@ class MQTTTemplateConfig(BaseModel):
             return "[" + ", ".join(items) + "]"
 
         if isinstance(value, str):
-            if value in placeholder_map:
-                clean_name = placeholder_map[value]
+            if value in cls.PLACEHOLDER_TO_VARIABLE:
+                clean_name = cls.PLACEHOLDER_TO_VARIABLE[value]
                 if part == "payload":
                     return f"{{{{{clean_name} | tojson}}}}"
                 return f"{{{{{clean_name}}}}}"
-            for placeholder, clean_name in placeholder_map.items():
+            for placeholder, clean_name in cls.PLACEHOLDER_TO_VARIABLE.items():
                 value = value.replace(placeholder, f"{{{{{clean_name}}}}}")
             if part == "payload":
                 return json.dumps(value)

--- a/encodapy/config/mqtt_messages_template.py
+++ b/encodapy/config/mqtt_messages_template.py
@@ -290,15 +290,6 @@ class MQTTTemplateConfig(BaseModel):
         Exact placeholder strings are emitted as bare Jinja expressions so that numbers,
         booleans, lists and dicts remain native after rendering.
         """
-        placeholder_map = {
-            "__OUTPUT_ENTITY__": "output_entity",
-            "__OUTPUT_ATTRIBUTE__": "output_attribute",
-            "__OUTPUT_VALUE__": "output_value",
-            "__OUTPUT_UNIT__": "output_unit",
-            "__OUTPUT_TIME__": "output_time",
-            "__MQTT_TOPIC_PREFIX__": "mqtt_topic_prefix",
-        }
-
         if isinstance(value, dict):
             items = [
                 f"{json.dumps(key)}: {cls._serialize_template_value(item, part)}"

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -760,8 +760,11 @@ class MqttConnection:
                     if output_attribute.timestamp
                     else None
                 ),
+                "mqtt_topic_prefix": self.mqtt_params.topic_prefix,
             }
-            for placeholder_name in output_attribute.mqtt_format.payload_embedded_placeholders:
+            for (
+                placeholder_name
+            ) in output_attribute.mqtt_format.payload_embedded_placeholders:
                 render_values[placeholder_name] = self._sanitize_embedded_payload_value(
                     render_values.get(placeholder_name),
                     f"__{placeholder_name.upper()}__",

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -761,20 +761,10 @@ class MqttConnection:
                     else None
                 ),
             }
-            placeholder_names = {
-                "output_entity": "__OUTPUT_ENTITY__",
-                "output_attribute": "__OUTPUT_ATTRIBUTE__",
-                "output_value": "__OUTPUT_VALUE__",
-                "output_unit": "__OUTPUT_UNIT__",
-                "output_time": "__OUTPUT_TIME__",
-                "mqtt_topic_prefix": "__MQTT_TOPIC_PREFIX__",
-            }
-            for (
-                placeholder_name
-            ) in output_attribute.mqtt_format.payload_embedded_placeholders:
+            for placeholder_name in output_attribute.mqtt_format.payload_embedded_placeholders:
                 render_values[placeholder_name] = self._sanitize_embedded_payload_value(
                     render_values.get(placeholder_name),
-                    placeholder_names[placeholder_name],
+                    f"__{placeholder_name.upper()}__",
                 )
 
             payload = output_attribute.mqtt_format.payload.render(**render_values)

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -55,6 +55,46 @@ class MqttConnection:
         self._mqtt_connected = False
         self._mqtt_connection_event = threading.Event()
 
+    @staticmethod
+    def _sanitize_embedded_payload_value(value: object, placeholder: str) -> str:
+        """
+        Convert embedded payload placeholder values to safe plain strings.
+
+        Values that would require JSON escaping are logged and omitted.
+        """
+        if value is None:
+            logger.warning(
+                f"MQTT payload placeholder {placeholder} has value None and will be omitted."
+            )
+            return ""
+
+        if isinstance(value, (dict, list, set, tuple)):
+            logger.warning(
+                f"MQTT payload placeholder {placeholder} received unsupported type "
+                f"{type(value).__name__} and will be omitted."
+            )
+            return ""
+
+        try:
+            string_value = str(value)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                f"MQTT payload placeholder {placeholder} could not be rendered "
+                f"and will be omitted: {exc}"
+            )
+            return ""
+
+        if any(
+            char in string_value for char in ('"', "\\", "\b", "\f", "\n", "\r", "\t")
+        ):
+            logger.warning(
+                f"MQTT payload placeholder {placeholder} contains characters "
+                "that would require JSON escaping and will be omitted."
+            )
+            return ""
+
+        return string_value
+
     def load_mqtt_params(self) -> None:
         """
         Function to load the MQTT parameters from the environment variables
@@ -706,19 +746,38 @@ class MqttConnection:
                 )
 
         elif isinstance(output_attribute.mqtt_format, MQTTTemplateConfig):
-            payload = output_attribute.mqtt_format.payload.render(
-                output_entity=output_entity.id_interface,
-                output_attribute=output_attribute.id_interface,
-                output_value=output_attribute.value,
-                output_unit=output_attribute.unit.value if output_attribute.unit else None,
-                output_time=(
+            render_values = {
+                "output_entity": output_entity.id_interface,
+                "output_attribute": output_attribute.id_interface,
+                "output_value": output_attribute.value,
+                "output_unit": output_attribute.unit.value
+                if output_attribute.unit
+                else None,
+                "output_time": (
                     output_attribute.timestamp.strftime(
                         output_attribute.mqtt_format.time_format
                     )
                     if output_attribute.timestamp
                     else None
                 ),
-            )
+            }
+            placeholder_names = {
+                "output_entity": "__OUTPUT_ENTITY__",
+                "output_attribute": "__OUTPUT_ATTRIBUTE__",
+                "output_value": "__OUTPUT_VALUE__",
+                "output_unit": "__OUTPUT_UNIT__",
+                "output_time": "__OUTPUT_TIME__",
+                "mqtt_topic_prefix": "__MQTT_TOPIC_PREFIX__",
+            }
+            for (
+                placeholder_name
+            ) in output_attribute.mqtt_format.payload_embedded_placeholders:
+                render_values[placeholder_name] = self._sanitize_embedded_payload_value(
+                    render_values.get(placeholder_name),
+                    placeholder_names[placeholder_name],
+                )
+
+            payload = output_attribute.mqtt_format.payload.render(**render_values)
 
         else:
             raise NotSupportedError(

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -296,7 +296,8 @@ class MqttConnection:
 
         Args:
             topic (str): The topic to publish the message to
-            payload (Union[str, float, int, bool, dict, list, DataFrame, Series, None]): payload to publish
+            payload (Union[str, float, int, bool, dict, list, DataFrame, Series, None]): \
+                payload to publish
         """
         if not self.mqtt_client:
             raise NotSupportedError(

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -14,7 +14,7 @@ from typing import Optional, Union
 import paho.mqtt.client as mqtt
 from loguru import logger
 from paho.mqtt.enums import CallbackAPIVersion
-from pandas import DataFrame
+from pandas import DataFrame, Series
 
 from encodapy.config import (
     ConfigModel,
@@ -286,7 +286,7 @@ class MqttConnection:
     def publish(
         self,
         topic: str,
-        payload: Union[str, float, int, bool, dict, list, DataFrame, None],
+        payload: Union[str, float, int, bool, dict, list, DataFrame, Series, None],
     ) -> None:
         """
         Function to publish a message (payload) to a topic.
@@ -296,7 +296,7 @@ class MqttConnection:
 
         Args:
             topic (str): The topic to publish the message to
-            payload (Union[str, float, int, bool, dict, list, DataFrame, None]): payload to publish
+            payload (Union[str, float, int, bool, dict, list, DataFrame, Series, None]): payload to publish
         """
         if not self.mqtt_client:
             raise NotSupportedError(
@@ -310,19 +310,19 @@ class MqttConnection:
         logger.debug(f"Published to topic {topic}: {payload}")
 
     def prepare_payload_for_publish(
-        self, payload: Union[str, float, int, bool, dict, list, DataFrame, None]
+        self, payload: Union[str, float, int, bool, dict, list, DataFrame, Series, None]
     ) -> Union[str, None]:
         """
         Function to prepare the payload for publishing.
 
-        Converts the payload to a JSON string if it is a dict, list or DataFrame.
+        Converts the payload to a JSON string if it is a dict, list, DataFrame or Series.
         If the payload is a string, float, int or bool, it is converted to a string.
         If the payload is None or an unsupported type, it is set to None.
         """
         try:
             if isinstance(payload, (dict, list)):
                 payload = json.dumps(payload)
-            elif isinstance(payload, DataFrame):
+            elif isinstance(payload, (DataFrame, Series)):
                 payload = payload.to_json()
             elif isinstance(payload, (str, float, int, bool)):
                 payload = str(payload)
@@ -719,16 +719,18 @@ class MqttConnection:
 
     def _prepare_mqtt_payload(
         self, output_entity: OutputModel, output_attribute: AttributeModel
-    ) -> Union[str, float, int, bool, dict, list, DataFrame, None]:
+    ) -> Union[str, float, int, bool, dict, list, DataFrame, Series, None]:
         """
         Function to prepare the MQTT payload based on the output attribute's mqtt_format.
         Args:
             output_entity (OutputModel): The output entity.
             output_attribute (AttributeModel): The output attribute.
         Returns:
-            Union[str, float, int, bool, dict, list, DataFrame, None]: The prepared payload.
+            Union[str, float, int, bool, dict, list, DataFrame, Series, None]: The prepared payload.
         """
-        payload: Union[str, float, int, bool, dict, list, DataFrame, None] = None
+        payload: Union[str, float, int, bool, dict, list, DataFrame, Series, None] = (
+            None
+        )
         if output_attribute.mqtt_format is MQTTFormatTypes.PLAIN:
             payload = output_attribute.value
         elif (

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -9,8 +9,7 @@ import re
 import threading
 import time
 from datetime import datetime, timezone
-from enum import Enum
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import paho.mqtt.client as mqtt
 from loguru import logger
@@ -707,24 +706,18 @@ class MqttConnection:
                 )
 
         elif isinstance(output_attribute.mqtt_format, MQTTTemplateConfig):
-            payload_context = {
-                "output_entity": output_entity.id_interface,
-                "output_attribute": output_attribute.id_interface,
-                "output_value": output_attribute.value,
-                "output_unit": output_attribute.unit,
-                "output_time": (
+            payload = output_attribute.mqtt_format.payload.render(
+                output_entity=output_entity.id_interface,
+                output_attribute=output_attribute.id_interface,
+                output_value=output_attribute.value,
+                output_unit=output_attribute.unit.value if output_attribute.unit else None,
+                output_time=(
                     output_attribute.timestamp.strftime(
                         output_attribute.mqtt_format.time_format
                     )
                     if output_attribute.timestamp
                     else None
                 ),
-            }
-            payload = output_attribute.mqtt_format.payload.render(
-                **{
-                    key: self._normalize_template_context_value(value)
-                    for key, value in payload_context.items()
-                }
             )
 
         else:
@@ -732,25 +725,6 @@ class MqttConnection:
                 f"MQTT format {output_attribute.mqtt_format} is not supported."
             )
         return payload
-
-    def _normalize_template_context_value(self, value: Any) -> Any:
-        """
-        Normalize render-context values so Jinja `tojson` can serialize them reliably.
-
-        Enums are converted to their primitive value recursively for nested structures.
-        """
-        if isinstance(value, Enum):
-            return value.value
-        if isinstance(value, dict):
-            return {
-                key: self._normalize_template_context_value(item)
-                for key, item in value.items()
-            }
-        if isinstance(value, list):
-            return [self._normalize_template_context_value(item) for item in value]
-        if isinstance(value, tuple):
-            return tuple(self._normalize_template_context_value(item) for item in value)
-        return value
 
     def _prepare_mqtt_topic(
         self,

--- a/encodapy/service/communication/mqtt_connection.py
+++ b/encodapy/service/communication/mqtt_connection.py
@@ -9,7 +9,8 @@ import re
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Optional, Union
+from enum import Enum
+from typing import Any, Optional, Union
 
 import paho.mqtt.client as mqtt
 from loguru import logger
@@ -706,18 +707,24 @@ class MqttConnection:
                 )
 
         elif isinstance(output_attribute.mqtt_format, MQTTTemplateConfig):
-            payload = output_attribute.mqtt_format.payload.render(
-                output_entity=output_entity.id_interface,
-                output_attribute=output_attribute.id_interface,
-                output_value=output_attribute.value,
-                output_unit=output_attribute.unit,
-                output_time=(
+            payload_context = {
+                "output_entity": output_entity.id_interface,
+                "output_attribute": output_attribute.id_interface,
+                "output_value": output_attribute.value,
+                "output_unit": output_attribute.unit,
+                "output_time": (
                     output_attribute.timestamp.strftime(
                         output_attribute.mqtt_format.time_format
                     )
                     if output_attribute.timestamp
                     else None
                 ),
+            }
+            payload = output_attribute.mqtt_format.payload.render(
+                **{
+                    key: self._normalize_template_context_value(value)
+                    for key, value in payload_context.items()
+                }
             )
 
         else:
@@ -725,6 +732,25 @@ class MqttConnection:
                 f"MQTT format {output_attribute.mqtt_format} is not supported."
             )
         return payload
+
+    def _normalize_template_context_value(self, value: Any) -> Any:
+        """
+        Normalize render-context values so Jinja `tojson` can serialize them reliably.
+
+        Enums are converted to their primitive value recursively for nested structures.
+        """
+        if isinstance(value, Enum):
+            return value.value
+        if isinstance(value, dict):
+            return {
+                key: self._normalize_template_context_value(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._normalize_template_context_value(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._normalize_template_context_value(item) for item in value)
+        return value
 
     def _prepare_mqtt_topic(
         self,

--- a/tests/test_component_unit_validation.py
+++ b/tests/test_component_unit_validation.py
@@ -1,3 +1,5 @@
+"""Tests for unit harmonization in component configuration models."""
+
 import pytest
 from pydantic import Field
 
@@ -10,11 +12,15 @@ from encodapy.utils.units import DataUnits
 
 
 class DemoInputData(InputData):
+    """Minimal input model for testing unit conversion on component fields."""
+
     temperature: DataPointNumber = Field(..., json_schema_extra={"unit": "KEL"})
     status_text: DataPointString = Field(..., json_schema_extra={"unit": "KWT"})
 
 
 def test_component_data_converts_numeric_values_to_field_unit() -> None:
+    """Numeric datapoints are converted to the unit declared on the target field."""
+
     model = DemoInputData(
         temperature=DataPointNumber(value=0.0, unit=DataUnits.DEGREECELSIUS),
         status_text=DataPointString(value="on", unit=DataUnits.WTT),
@@ -25,6 +31,8 @@ def test_component_data_converts_numeric_values_to_field_unit() -> None:
 
 
 def test_component_data_does_not_relabel_non_convertible_values() -> None:
+    """Non-convertible values keep their original value and unit metadata."""
+
     model = DemoInputData(
         temperature=DataPointNumber(value=273.15, unit=DataUnits.KELVIN),
         status_text=DataPointString(value="on", unit=DataUnits.WTT),
@@ -35,6 +43,8 @@ def test_component_data_does_not_relabel_non_convertible_values() -> None:
 
 
 def test_two_point_controller_harmonizes_hysteresis_unit_to_setpoint() -> None:
+    """Hysteresis is converted to the same unit as the configured setpoint."""
+
     model = TwoPointControllerConfigData(
         hysteresis=DataPointNumber(value=500.0, unit=DataUnits.WTT),
         setpoint=DataPointNumber(value=1.0, unit=DataUnits.KWT),

--- a/tests/test_fiware_unit_adjustment.py
+++ b/tests/test_fiware_unit_adjustment.py
@@ -1,3 +1,7 @@
+"""Tests for FIWARE unit adjustment behavior."""
+
+# pylint: disable=protected-access
+
 import pytest
 
 from encodapy.config.models import AttributeModel
@@ -6,6 +10,8 @@ from encodapy.utils.units import DataUnits
 
 
 def test_adjust_units_for_fiware_converts_value_and_metadata() -> None:
+    """Convertible values are transformed and metadata reflects the FIWARE unit."""
+
     connection = FiwareConnection()
     attribute = AttributeModel(id="power", value=1000.0, unit=DataUnits.WTT)
 
@@ -24,6 +30,8 @@ def test_adjust_units_for_fiware_converts_value_and_metadata() -> None:
 
 
 def test_adjust_units_for_fiware_preserves_actual_unit_metadata_on_failure() -> None:
+    """On failed conversion, value and metadata keep the original physical unit."""
+
     connection = FiwareConnection()
     attribute = AttributeModel(id="power", value=1000.0, unit=DataUnits.WTT)
 

--- a/tests/test_mqtt_connection_publish.py
+++ b/tests/test_mqtt_connection_publish.py
@@ -1,3 +1,7 @@
+"""Tests for MQTT publish rendering and dispatch behavior."""
+
+# pylint: disable=protected-access
+
 import json
 from datetime import datetime, timezone
 
@@ -16,6 +20,8 @@ from encodapy.utils.units import DataUnits
 
 
 def test_send_data_to_mqtt_renders_template_and_calls_publish() -> None:
+    """Template placeholders are rendered and a single publish call is emitted."""
+
     connection = MqttConnection()
     connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
     connection.config = object()  # type: ignore[assignment]
@@ -73,6 +79,8 @@ def test_send_data_to_mqtt_renders_template_and_calls_publish() -> None:
 
 
 def test_send_data_to_mqtt_skips_none_values_if_enabled() -> None:
+    """Attributes with None values are skipped when skip_none_values is enabled."""
+
     connection = MqttConnection()
     connection.mqtt_params = MQTTEnvVariables(
         topic_prefix="encoda",
@@ -107,10 +115,12 @@ def test_send_data_to_mqtt_skips_none_values_if_enabled() -> None:
         output_attributes=[output_attribute],
     )
 
-    assert published == []
+    assert not published
 
 
 def test_send_data_to_mqtt_without_template_uses_plain_topic_and_payload() -> None:
+    """Plain MQTT format publishes raw payload to the default topic structure."""
+
     connection = MqttConnection()
     connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
     connection.config = object()  # type: ignore[assignment]
@@ -151,6 +161,8 @@ def test_send_data_to_mqtt_without_template_uses_plain_topic_and_payload() -> No
 def test_send_data_to_mqtt_omits_problematic_embedded_payload_placeholder_and_logs() -> (
     None
 ):
+    """Unsafe embedded placeholder content is removed and a warning is logged."""
+
     connection = MqttConnection()
     connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
     connection.config = object()  # type: ignore[assignment]

--- a/tests/test_mqtt_connection_publish.py
+++ b/tests/test_mqtt_connection_publish.py
@@ -10,6 +10,7 @@ from encodapy.config import (
 )
 from encodapy.config.mqtt_messages_template import MQTTTemplateConfig
 from encodapy.service.communication.mqtt_connection import MqttConnection
+from encodapy.utils.units import DataUnits
 
 
 def test_send_data_to_mqtt_renders_template_and_calls_publish() -> None:
@@ -40,7 +41,7 @@ def test_send_data_to_mqtt_renders_template_and_calls_publish() -> None:
         id="temp",
         id_interface="temperature",
         value=21.5,
-        unit="CEL",
+        unit=DataUnits.DEGREECELSIUS,
         timestamp=datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc),
         mqtt_format=template,
     )

--- a/tests/test_mqtt_connection_publish.py
+++ b/tests/test_mqtt_connection_publish.py
@@ -1,0 +1,145 @@
+import json
+from datetime import datetime, timezone
+
+from encodapy.config import (
+    AttributeModel,
+    Interfaces,
+    MQTTEnvVariables,
+    MQTTFormatTypes,
+    OutputModel,
+)
+from encodapy.config.mqtt_messages_template import MQTTTemplateConfig
+from encodapy.service.communication.mqtt_connection import MqttConnection
+
+
+def test_send_data_to_mqtt_renders_template_and_calls_publish() -> None:
+    connection = MqttConnection()
+    connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
+    connection.config = object()  # type: ignore[assignment]
+    connection.mqtt_client = object()  # prevent pre-check from failing
+    connection._mqtt_connected = True
+
+    template = MQTTTemplateConfig(
+        topic="__MQTT_TOPIC_PREFIX__/__OUTPUT_ENTITY__/__OUTPUT_ATTRIBUTE__",
+        payload={
+            "DATAPOINT": "__OUTPUT_ATTRIBUTE__",
+            "VALUE": "__OUTPUT_VALUE__",
+            "UNIT": "__OUTPUT_UNIT__",
+            "TIME": "__OUTPUT_TIME__",
+        },
+        time_format="%Y-%m-%dT%H:%M:%SZ",
+    )
+
+    output_entity = OutputModel(
+        id="entity_1",
+        id_interface="heatpump",
+        interface=Interfaces.MQTT,
+        attributes=[],
+    )
+    output_attribute = AttributeModel(
+        id="temp",
+        id_interface="temperature",
+        value=21.5,
+        unit="CEL",
+        timestamp=datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc),
+        mqtt_format=template,
+    )
+
+    published: list[tuple[str, str]] = []
+
+    def capture_publish(topic: str, payload: str) -> None:
+        published.append((topic, payload))
+
+    connection.publish = capture_publish  # type: ignore[method-assign]
+
+    connection.send_data_to_mqtt(
+        output_entity=output_entity,
+        output_attributes=[output_attribute],
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert topic == "encoda/heatpump/temperature"
+    payload_dict = json.loads(payload)
+    assert payload_dict == {
+        "DATAPOINT": "temperature",
+        "VALUE": 21.5,
+        "UNIT": "CEL",
+        "TIME": "2026-04-28T12:00:00Z",
+    }
+
+
+def test_send_data_to_mqtt_skips_none_values_if_enabled() -> None:
+    connection = MqttConnection()
+    connection.mqtt_params = MQTTEnvVariables(
+        topic_prefix="encoda",
+        skip_none_values=True,
+    )
+    connection.config = object()  # type: ignore[assignment]
+    connection.mqtt_client = object()  # prevent pre-check from failing
+    connection._mqtt_connected = True
+
+    output_entity = OutputModel(
+        id="entity_1",
+        id_interface="heatpump",
+        interface=Interfaces.MQTT,
+        attributes=[],
+    )
+    output_attribute = AttributeModel(
+        id="temp",
+        id_interface="temperature",
+        value=None,
+        mqtt_format=MQTTFormatTypes.PLAIN,
+    )
+
+    published: list[tuple[str, object]] = []
+
+    def capture_publish(topic: str, payload: object) -> None:
+        published.append((topic, payload))
+
+    connection.publish = capture_publish  # type: ignore[method-assign]
+
+    connection.send_data_to_mqtt(
+        output_entity=output_entity,
+        output_attributes=[output_attribute],
+    )
+
+    assert published == []
+
+
+def test_send_data_to_mqtt_without_template_uses_plain_topic_and_payload() -> None:
+    connection = MqttConnection()
+    connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
+    connection.config = object()  # type: ignore[assignment]
+    connection.mqtt_client = object()  # prevent pre-check from failing
+    connection._mqtt_connected = True
+
+    output_entity = OutputModel(
+        id="entity_1",
+        id_interface="heatpump",
+        interface=Interfaces.MQTT,
+        attributes=[],
+    )
+    output_attribute = AttributeModel(
+        id="power",
+        id_interface="power",
+        value=123.4,
+        mqtt_format=MQTTFormatTypes.PLAIN,
+    )
+
+    published: list[tuple[str, object]] = []
+
+    def capture_publish(topic: str, payload: object) -> None:
+        published.append((topic, payload))
+
+    connection.publish = capture_publish  # type: ignore[method-assign]
+
+    connection.send_data_to_mqtt(
+        output_entity=output_entity,
+        output_attributes=[output_attribute],
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert topic == "encoda/heatpump/power"
+    assert payload == 123.4

--- a/tests/test_mqtt_connection_publish.py
+++ b/tests/test_mqtt_connection_publish.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timezone
 
+from loguru import logger
+
 from encodapy.config import (
     AttributeModel,
     Interfaces,
@@ -144,3 +146,64 @@ def test_send_data_to_mqtt_without_template_uses_plain_topic_and_payload() -> No
     topic, payload = published[0]
     assert topic == "encoda/heatpump/power"
     assert payload == 123.4
+
+
+def test_send_data_to_mqtt_omits_problematic_embedded_payload_placeholder_and_logs() -> (
+    None
+):
+    connection = MqttConnection()
+    connection.mqtt_params = MQTTEnvVariables(topic_prefix="encoda")
+    connection.config = object()  # type: ignore[assignment]
+    connection.mqtt_client = object()  # prevent pre-check from failing
+    connection._mqtt_connected = True
+
+    template = MQTTTemplateConfig(
+        topic="__MQTT_TOPIC_PREFIX__/heatpump/state",
+        payload={
+            "LABEL": "sensor __OUTPUT_ATTRIBUTE__ active",
+        },
+    )
+
+    output_entity = OutputModel(
+        id="entity_1",
+        id_interface="heatpump",
+        interface=Interfaces.MQTT,
+        attributes=[],
+    )
+    output_attribute = AttributeModel(
+        id="temp",
+        id_interface='temperature "zone_1"',
+        value=21.5,
+        mqtt_format=template,
+    )
+
+    published: list[tuple[str, str]] = []
+    log_messages: list[str] = []
+
+    def capture_publish(topic: str, payload: str) -> None:
+        published.append((topic, payload))
+
+    connection.publish = capture_publish  # type: ignore[method-assign]
+
+    handler_id = logger.add(
+        lambda message: log_messages.append(str(message)),
+        level="WARNING",
+        format="{message}",
+    )
+    try:
+        connection.send_data_to_mqtt(
+            output_entity=output_entity,
+            output_attributes=[output_attribute],
+        )
+    finally:
+        logger.remove(handler_id)
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert topic == "encoda/heatpump/state"
+    payload_dict = json.loads(payload)
+    assert payload_dict["LABEL"] == "sensor  active"
+    assert any(
+        "MQTT payload placeholder __OUTPUT_ATTRIBUTE__ contains characters" in message
+        for message in log_messages
+    )

--- a/tests/test_mqtt_template_config.py
+++ b/tests/test_mqtt_template_config.py
@@ -16,7 +16,7 @@ def test_topic_template_replaces_embedded_placeholders() -> None:
     topic = template.topic.render(
         output_entity="building_1",
         output_attribute="temperature",
-        mqtt_topic_prefix="encoda",
+        mqtt_topic_prefix="encodapy",
     )
 
     assert topic == "encodapy/develop/building_1/temperature"

--- a/tests/test_mqtt_template_config.py
+++ b/tests/test_mqtt_template_config.py
@@ -1,0 +1,41 @@
+import json
+
+from encodapy.config.mqtt_messages_template import MQTTTemplateConfig
+
+
+def test_topic_template_replaces_embedded_placeholders() -> None:
+    template = MQTTTemplateConfig(
+        topic="__MQTT_TOPIC_PREFIX__/develop/__OUTPUT_ENTITY__/__OUTPUT_ATTRIBUTE__",
+        payload={"value": "__OUTPUT_VALUE__"},
+    )
+
+    topic = template.topic.render(
+        output_entity="building_1",
+        output_attribute="temperature",
+        mqtt_topic_prefix="encoda",
+    )
+
+    assert topic == "encoda/develop/building_1/temperature"
+
+
+def test_payload_template_keeps_native_type_for_exact_placeholder() -> None:
+    template = MQTTTemplateConfig(
+        topic="out",
+        payload={
+            "value": "__OUTPUT_VALUE__",
+            "label": "sensor __OUTPUT_ATTRIBUTE__",
+        },
+    )
+
+    payload = template.payload.render(
+        output_entity="building_1",
+        output_attribute="temperature",
+        output_value=42,
+        output_unit="degC",
+        output_time=None,
+        mqtt_topic_prefix="encoda",
+    )
+    payload_dict = json.loads(payload)
+
+    assert payload_dict["value"] == 42
+    assert payload_dict["label"] == "sensor temperature"

--- a/tests/test_mqtt_template_config.py
+++ b/tests/test_mqtt_template_config.py
@@ -1,9 +1,13 @@
+"""Tests for MQTT topic and payload template rendering."""
+
 import json
 
 from encodapy.config.mqtt_messages_template import MQTTTemplateConfig
 
 
 def test_topic_template_replaces_embedded_placeholders() -> None:
+    """Topic templates replace all embedded placeholders with runtime values."""
+
     template = MQTTTemplateConfig(
         topic="__MQTT_TOPIC_PREFIX__/develop/__OUTPUT_ENTITY__/__OUTPUT_ATTRIBUTE__",
         payload={"value": "__OUTPUT_VALUE__"},
@@ -15,10 +19,12 @@ def test_topic_template_replaces_embedded_placeholders() -> None:
         mqtt_topic_prefix="encoda",
     )
 
-    assert topic == "encoda/develop/building_1/temperature"
+    assert topic == "encodapy/develop/building_1/temperature"
 
 
 def test_payload_template_keeps_native_type_for_exact_placeholder() -> None:
+    """Exact payload placeholders preserve native JSON scalar types."""
+
     template = MQTTTemplateConfig(
         topic="out",
         payload={

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,3 +1,5 @@
+"""Tests for unit conversion helpers and time-unit normalization."""
+
 import pandas as pd
 import pytest
 
@@ -11,6 +13,8 @@ from encodapy.utils.units import (
 
 
 def test_adjust_unit_of_value_converts_seconds_to_minutes() -> None:
+    """Second-to-minute conversion returns the expected numeric factor."""
+
     adjusted_value = adjust_unit_of_value(
         value=120,
         unit_actual=DataUnits.SECOND,
@@ -21,6 +25,8 @@ def test_adjust_unit_of_value_converts_seconds_to_minutes() -> None:
 
 
 def test_adjust_unit_of_value_handles_temperature_offset() -> None:
+    """Temperature conversion applies additive offsets correctly."""
+
     adjusted_value = adjust_unit_of_value(
         value=0,
         unit_actual=DataUnits.DEGREECELSIUS,
@@ -31,6 +37,8 @@ def test_adjust_unit_of_value_handles_temperature_offset() -> None:
 
 
 def test_adjust_unit_of_value_raises_for_incompatible_units() -> None:
+    """Incompatible dimensions raise a ValueError."""
+
     with pytest.raises(ValueError, match="Incompatible units"):
         adjust_unit_of_value(
             value=1,
@@ -40,6 +48,8 @@ def test_adjust_unit_of_value_raises_for_incompatible_units() -> None:
 
 
 def test_adjust_units_returns_none_for_non_convertible_string() -> None:
+    """Non-numeric scalar input returns None instead of raising."""
+
     adjusted_value = adjust_units(
         value="not-a-number",
         unit_actual=DataUnits.WTT,
@@ -50,6 +60,8 @@ def test_adjust_units_returns_none_for_non_convertible_string() -> None:
 
 
 def test_adjust_units_converts_series_and_dataframe_values() -> None:
+    """Vectorized conversions work for both Series and DataFrame inputs."""
+
     values = pd.Series([60.0, 120.0])
     adjusted_series = adjust_units(
         value=values,
@@ -82,6 +94,8 @@ def test_adjust_units_converts_series_and_dataframe_values() -> None:
 def test_get_time_unit_seconds(
     time_unit: TimeUnits | DataUnits | str, expected_seconds: float
 ) -> None:
+    """Known time units resolve to their corresponding number of seconds."""
+
     seconds = get_time_unit_seconds(time_unit)
 
     assert seconds == pytest.approx(expected_seconds)


### PR DESCRIPTION
This pull request introduces enhanced handling and safety for MQTT message templates, especially regarding embedded placeholders in payloads. It adds logic to identify placeholders within payload strings, ensures their safe rendering (preventing problematic values from being injected), and provides comprehensive tests for these behaviors.

**Template rendering and placeholder handling improvements:**

* Added a `PLACEHOLDER_TO_VARIABLE` mapping and a `payload_embedded_placeholders` field to `MQTTTemplateConfig` to systematically identify and track placeholders embedded within payload strings. This enables safer and more predictable template rendering. [[1]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fL9-R13) [[2]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR74-R89)
* Implemented the `_collect_embedded_payload_placeholders` method to recursively extract placeholder names from complex payload structures (dicts, lists, strings) during template loading. [[1]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR230-R264) [[2]](diffhunk://#diff-2f17c7723425deb10fe8321b80373dd2c220c1431c23702008e13104c38c554fR168-R170)
* Updated the template serialization logic to replace embedded placeholders in strings with their corresponding Jinja2 variable names, ensuring correct rendering in both topic and payload templates.

**Safety and sanitization for payload values:**

* Introduced `_sanitize_embedded_payload_value` in `MqttConnection` to convert embedded placeholder values to safe strings, omitting any that are `None`, non-stringifiable, or contain characters requiring JSON escaping, with appropriate warnings logged.
* Modified payload rendering in `_prepare_mqtt_payload` to use sanitized values for embedded placeholders, preventing injection of problematic content into MQTT messages.

**Testing:**

* Added comprehensive tests for MQTT template rendering, placeholder substitution, and the handling of problematic or `None` values in payloads, ensuring robustness and correct logging behavior. [[1]](diffhunk://#diff-5b91f33d8f218ba8fc6745f89cf4081c9282624ae8b02412efdba66402f0b629R1-R209) [[2]](diffhunk://#diff-c3fe773d31e3397b7331a5ad79059e028fd769cde5c49059430eb309b487d294R1-R41)